### PR TITLE
fix taxonomies list containing only the first 10 taxonomies

### DIFF
--- a/src/assets/js/select-dynamic-control.jsx
+++ b/src/assets/js/select-dynamic-control.jsx
@@ -114,7 +114,7 @@ export default compose([
 			};
 		} else if (ownProps.entityType === 'taxonomy-type') {
 			return {
-				items: select("core").getTaxonomies(),
+				items: select("core").getTaxonomies({ per_page: -1 }),
 			};
 		} else if (ownProps.entityType === 'post' && ownProps.conditional !== '' && Array.isArray(ownProps.postType)) {
 			let items = [];


### PR DESCRIPTION
This is the same issue fixed in 9f85fa6dffc782b9e2bc8f09bec665d98f4be5c1 but for taxonomies instead of post types.